### PR TITLE
Select based on UTC times

### DIFF
--- a/afedit.cpp
+++ b/afedit.cpp
@@ -11,7 +11,17 @@
 #include <casacore/measures/Measures/MCEpoch.h>
 #include <casacore/measures/Measures/MeasConvert.h>
 #include <casacore/measures/Measures/MEpoch.h>
+#include <casacore/casa/Quanta/MVTime.h>
 #include <casacore/measures/Measures/MPosition.h>
+
+
+// Convert casacore time to ISO 8601 format
+std::string TimeToString(const casacore::MVTime& time)
+{
+	std::string out = time.string((casacore::MVTime::formatTypes)(casacore::MVTime::YMD), 8);
+	out[4] = '-'; out[7] = '-'; out[10] = 'T';
+	return out;
+}
 
 int main(int argc, char* argv[])
 {
@@ -78,7 +88,8 @@ int main(int argc, char* argv[])
 		TimeRange range(lstStart.ValueOr(0.0), lstEnd.ValueOr(24.0));
 		size_t lstStartIndex = file.NTimesteps(), lstEndIndex = 0;
 		double firstLst = 0.0, lastLst = 0.0;
-		
+		casacore::MVTime firstUtc, lastUtc;
+
 		size_t
 			tStart = intervalStart.ValueOr(0),
 			tEnd = intervalEnd.ValueOr(file.NTimesteps());
@@ -99,10 +110,16 @@ int main(int argc, char* argv[])
 				lstEndIndex = timestep;
 			}
 			if(timestep == tStart)
+			{
 				firstLst = hour;
-			if(timestep+1 == tEnd)
+				firstUtc = timeEpoch.getValue();
+			}
+			if(timestep+1 == tEnd) {
 				lastLst = hour;
+				lastUtc = timeEpoch.getValue();
+			}
 		}
+		std::cout << "UTC range of observation: " << TimeToString(firstUtc) << " - " << TimeToString(lastUtc) << ".\n";
 		std::cout << "LST range of observation: " << RaDecCoord::RAToString(firstLst*(M_PI/12.0)) << " - " << RaDecCoord::RAToString(lastLst*(M_PI/12.0)) << " (in hours: " << firstLst << " - " << lastLst << ").\n";
 		if(showLst)
 			return 0;

--- a/afedit.cpp
+++ b/afedit.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
 		{
 			file.SeekToTimestep(timestep);
 			Timestep t = file.ReadMetadata();
-			double obsTime = AartfaacFile::TimeToCasa((t.startTime + t.endTime) * 0.5);
+			double obsTime = (t.startTime + t.endTime) * 0.5;
 			casacore::MEpoch timeEpoch = casacore::MEpoch(casacore::MVEpoch(obsTime/86400.0), casacore::MEpoch::UTC);
 			casacore::MEpoch lst = casacore::MEpoch::Convert(timeEpoch, casacore::MEpoch::Ref(casacore::MEpoch::LAST, frame))();
 			double hour = lst.getValue().getDayFraction() * 24.0;

--- a/afedit.cpp
+++ b/afedit.cpp
@@ -29,6 +29,7 @@ int main(int argc, char* argv[])
 	Optional<size_t> intervalStart, intervalEnd;
 	Optional<double> lstStart, lstEnd;
 	bool showLst = false;
+
 	while(argi < argc && argv[argi][0] == '-')
 	{
 		std::string p(&argv[argi][1]);
@@ -79,7 +80,7 @@ int main(int argc, char* argv[])
 		outputFilename = nullptr;
 	else
 		outputFilename = argv[argi+1];
-		
+
 	if(lstStart.HasValue() || lstEnd.HasValue() || showLst)
 	{
 		AartfaacFile file(inputFilename);
@@ -93,7 +94,7 @@ int main(int argc, char* argv[])
 		size_t
 			tStart = intervalStart.ValueOr(0),
 			tEnd = intervalEnd.ValueOr(file.NTimesteps());
-		
+
 		// TODO this could be done with binary search to make it faster
 		for(size_t timestep=tStart; timestep!=tEnd; ++timestep)
 		{
@@ -133,7 +134,7 @@ int main(int argc, char* argv[])
 		intervalStart = lstStartIndex;
 		intervalEnd = lstEndIndex;
 	}
-	
+
 	std::ifstream inFile(inputFilename);
 	inFile.seekg(0, std::ios::end);
 	size_t filesize = inFile.tellg();
@@ -142,7 +143,7 @@ int main(int argc, char* argv[])
 		std::cerr << "Error reading file " << inputFilename << ".\n";
 		return 1;
 	}
-	
+
 	// Read first header
 	AartfaacHeader header;
 	inFile.seekg(0, std::ios::beg);
@@ -150,7 +151,7 @@ int main(int argc, char* argv[])
 	header.Check();
 	size_t blockSize = sizeof(std::complex<float>) * header.VisPerTimestep();
 	size_t timesteps = filesize / blockSize;
-	
+
 	if(!intervalStart.HasValue())
 		intervalStart = 0;
 	if(!intervalEnd.HasValue())
@@ -160,7 +161,7 @@ int main(int argc, char* argv[])
 		std::cerr << "Invalid trimming interval.\n";
 		return 1;
 	}
-	
+
 	// Copy the interval
 	std::ofstream outFile(outputFilename);
 	std::vector<char> block(sizeof(AartfaacHeader) + blockSize);


### PR DESCRIPTION
This adds functionality to afedit to trim a `.vis` file based on UTC times.

It fixes a bug in conversion to casacore times, which also affects LST selection.